### PR TITLE
Update BERT & GPT dropout value retrieving rule

### DIFF
--- a/epoi/inject/policy/bert.py
+++ b/epoi/inject/policy/bert.py
@@ -14,7 +14,7 @@ class InjectHFBertSelfAttentionPolicy(ModuleInjectPolicy):
             "hidden_size": orig.all_head_size,
             "num_attention_heads": orig.num_attention_heads,
             "is_decoder": False,
-            "attn_pdrop": orig.dropout.p,
+            "attn_pdrop": orig.attention_dropout.p if hasattr(orig, "attention_dropout") else orig.dropout.p,
             "resid_pdrop": 0,
             "attn_op_name": kwargs.get("attn_op_name", "cutlass"),
         }

--- a/epoi/inject/policy/gpt.py
+++ b/epoi/inject/policy/gpt.py
@@ -17,6 +17,8 @@ def find_dropout_prob(config_or_mod):
         attn_pdrop = config_or_mod.attn_pdrop
     elif hasattr(config_or_mod, "attn_dropout"):
         attn_pdrop = config_or_mod.attn_dropout
+    elif hasattr(config_or_mod, "dropout"):
+        attn_pdrop = config_or_mod.dropout
     else:
         raise ValueError("Cannot find attention dropout probability")
 
@@ -26,6 +28,8 @@ def find_dropout_prob(config_or_mod):
         resid_pdrop = config_or_mod.resid_dropout
     elif hasattr(config_or_mod, "resid_dropout"):
         resid_pdrop = config_or_mod.resid_dropout
+    elif hasattr(config_or_mod, "dropout"):
+        resid_pdrop = config_or_mod.dropout
     else:
         raise ValueError("Cannot find resid_pdrop or resid_dropout in config.")
 


### PR DESCRIPTION
As the title says, this PR adds additional rules to retrieve the dropout value in order to support albert, roberta, and opt models