### PR TITLE
Support for Bloom models

### DIFF
--- a/epoi/inject/policy/__init__.py
+++ b/epoi/inject/policy/__init__.py
@@ -1,12 +1,12 @@
 """Injection Policies."""
 from inspect import getmembers, ismodule
-from . import bert, gpt, t5
+from . import bert, gpt, t5, bloom
 
 
 def init_policy_list():
     """Initialize policy list with builtin policies under the namespace."""
     policies = {}  # mapping from policy class to status (bool)
-    for parent_mod in [bert, gpt, t5]:
+    for parent_mod in [bert, gpt, t5, bloom]:
         for name, mod in getmembers(parent_mod):
             if not ismodule(mod) and name.startswith("Inject") and name.endswith("Policy"):
                 policies[mod] = True

--- a/epoi/inject/policy/bloom.py
+++ b/epoi/inject/policy/bloom.py
@@ -1,0 +1,104 @@
+"""Bloom specific injection policies."""
+import torch
+
+from .base import ModuleInjectPolicy
+from ...ops.xformers_attn import BloomAttentionWithXF
+from ...ops.torchscript_ops import FusedBiasGELU
+
+
+class InjectHFBloomAttentionPolicy(ModuleInjectPolicy):
+    @staticmethod
+    def gen_init_config_from_object(orig, **kwargs):
+        args = {
+            "hidden_size": orig.hidden_size,
+            "num_attention_heads": orig.num_heads,
+            "attn_pdrop": orig.attention_dropout.p,
+            "resid_pdrop": orig.hidden_dropout,
+            "attn_op_name": kwargs.get("attn_op_name", "cutlass"),
+        }
+        return args
+
+    @staticmethod
+    def gen_init_config_from_config(*args, **kwargs):
+        config = args[0]
+        new_args = {
+            "hidden_size": config.hidden_size,
+            "num_attention_heads": config.n_head,
+            "attn_pdrop": config.attention_dropout,
+            "resid_pdrop": config.hidden_dropout,
+            "attn_op_name": kwargs.get("attn_op_name", "cutlass"),
+        }
+        return new_args
+
+    @staticmethod
+    def assign_params(this, orig, **kwargs):
+        this.qkv.weight = orig.query_key_value.weight
+        this.qkv.bias = orig.query_key_value.bias
+        this.out_proj.weight = orig.dense.weight
+        this.out_proj.bias = orig.dense.bias
+
+    @staticmethod
+    def target_modules():
+        """A list of target modules to be injected."""
+        import transformers.models.bloom.modeling_bloom
+        return [(transformers.models.bloom.modeling_bloom, "BloomAttention")]
+
+    @staticmethod
+    def inject_module(**kwargs):
+        """The custom module to inject."""
+        return BloomAttentionWithXF
+
+
+class InjectHFBloomMLPPolicy(ModuleInjectPolicy):
+    @staticmethod
+    def gen_init_config_from_object(orig):
+        hidden_size = orig.dense_h_to_4h.weight.shape[1]
+        args = {
+            "hidden_size": hidden_size,
+            "hidden_dropout": orig.hidden_dropout,
+        }
+        return args
+
+    @staticmethod
+    def assign_params(this, orig, **kwargs):
+        this.dense_h_to_4h.weight = orig.dense_h_to_4h.weight
+        this.act.bias = orig.dense_h_to_4h.bias
+        this.dense_4h_to_h.weight = orig.dense_4h_to_h.weight
+        this.dense_4h_to_h.bias = orig.dense_4h_to_h.bias
+
+    @staticmethod
+    def target_modules():
+        """A list of target modules to be injected."""
+        import transformers.models.bloom.modeling_bloom
+        return [(transformers.models.bloom.modeling_bloom, "BloomMLP")]
+
+    @staticmethod
+    def inject_module(**kwargs):
+        """The custom module to inject."""
+
+        class FusedMLP(torch.nn.Module):
+            """A wrapper MLP to make use of fused bias+gelu."""
+
+            def __init__(self, hidden_size, hidden_dropout):
+                super().__init__()
+                self.dense_h_to_4h = torch.nn.Linear(hidden_size, 4 * hidden_size, bias=False)
+                self.act = FusedBiasGELU(4 * hidden_size, prev_weight=self.dense_h_to_4h.weight)
+                self.dense_4h_to_h = torch.nn.Linear(4 * hidden_size, hidden_size)
+                self.dropout = torch.nn.Dropout(hidden_dropout)
+
+            def forward(self, hidden_states, residual):
+                hidden_states = self.dense_h_to_4h(hidden_states)
+                hidden_states = self.act(hidden_states)
+                hidden_states = self.dense_4h_to_h(hidden_states)
+                hidden_states = self.dropout(hidden_states) + residual
+                return hidden_states
+
+        return FusedMLP
+
+    @staticmethod
+    def gen_init_config_from_config(*args, **kwargs):
+        new_args = {
+            "hidden_size": config.hidden_size,
+            "hidden_dropout": config.hidden_dropout,
+        }
+        return new_args


### PR DESCRIPTION
On V100-32GB, `python3 -m epoi.benchmark --only-run bloom_attention` gives

```
INFO bencher: Correctness checking for native is passed
INFO bencher: Correctness checking for cutlass is passed
[----------- HF Bloom Attention and xFormer Attention ----------]
                                   |   HF   |  native  |  cutlass
1 threads: ------------------------------------------------------
      (4, 2048, 1024, 16, 250880)  |  45.0  |   44.4   |    17.8 

Times are in milliseconds (ms).

           Shape              HF    native    cutlass
---------------------------  ----  --------  ---------
(4, 2048, 1024, 16, 250880)  4240    4336     1168.5

Memory is in MBs and excludes inputs/outputs.
Note that memory is measured with only forward (but with activations).
```

This leads to a 20+% end-to-end training speedup for `bigscience/bloom-560m` after injection.