### PR TITLE
Support for loading from pretrained & some fixes

### DIFF
--- a/epoi/inject/inject.py
+++ b/epoi/inject/inject.py
@@ -69,6 +69,9 @@ class InjectModuleContext:
                 return state_dict
             return wrap_load_func
 
+        # Different policies may conflict with each other in the way they modify the state dict.
+        # HF will give detailed warnings later if there is any any mismatch
+        # between the state_dict and the model parameters.
         transformers.modeling_utils.load_state_dict = \
             wrap_load_state_dict(self.load_state_dict_backup, self.policies)
 
@@ -76,7 +79,7 @@ class InjectModuleContext:
         for policy in self.policies:
             policy.unhook()
 
-        if self.load_state_dict_backup:
+        if self.load_state_dict_backup is not None:
             import transformers.modeling_utils
             transformers.modeling_utils.load_state_dict = self.load_state_dict_backup
 

--- a/epoi/inject/policy/base.py
+++ b/epoi/inject/policy/base.py
@@ -102,3 +102,8 @@ class ModuleInjectPolicy:
     def gen_wrap_forward(orig_cls, forward):
         """Generate a wrapper to wrap the inject module's forward function."""
         return forward
+
+    @staticmethod
+    def load_state_dict_post_hook(state_dict):
+        """Rename the parameters in the state_dict for the injected modules"""
+        return state_dict

--- a/epoi/inject/policy/bert.py
+++ b/epoi/inject/policy/bert.py
@@ -143,8 +143,7 @@ class InjectHFBertOutputPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def load_state_dict_post_hook(state_dict):
-        new_names = []
-        old_names = []
+        name_pairs = []
         replace_rules = [
             ("output.LayerNorm.gamma", "LayerNorm.gamma", "fused_op.layer_norm.weight"),
             ("output.LayerNorm.beta", "LayerNorm.beta", "fused_op.layer_norm.bias"),
@@ -154,11 +153,10 @@ class InjectHFBertOutputPolicy(ModuleInjectPolicy):
             for rule in replace_rules:
                 if rule[0] in name and "attention" not in name:
                     new_name = name.replace(rule[1], rule[2])
-            if new_name:
-                new_names.append(new_name)
-                old_names.append(name)
+            if new_name is not None:
+                name_pairs.append((name, new_name))
 
-        for old_name, new_name in zip(old_names, new_names):
+        for old_name, new_name in name_pairs:
             state_dict[new_name] = state_dict.pop(old_name)
 
         return state_dict

--- a/epoi/inject/policy/bloom.py
+++ b/epoi/inject/policy/bloom.py
@@ -50,8 +50,7 @@ class InjectHFBloomAttentionPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def load_state_dict_post_hook(state_dict):
-        new_names = []
-        old_names = []
+        name_pairs = []
         replace_rules = [
             ("self_attention.query_key_value", "query_key_value", "qkv"),
             ("self_attention.dense", "dense", "out_proj"),
@@ -61,11 +60,10 @@ class InjectHFBloomAttentionPolicy(ModuleInjectPolicy):
             for rule in replace_rules:
                 if rule[0] in name:
                     new_name = name.replace(rule[1], rule[2])
-            if new_name:
-                new_names.append(new_name)
-                old_names.append(name)
+            if new_name is not None:
+                name_pairs.append((name, new_name))
 
-        for old_name, new_name in zip(old_names, new_names):
+        for old_name, new_name in name_pairs:
             state_dict[new_name] = state_dict.pop(old_name)
 
         return state_dict
@@ -128,8 +126,7 @@ class InjectHFBloomMLPPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def load_state_dict_post_hook(state_dict):
-        new_names = []
-        old_names = []
+        name_pairs = []
         replace_rules = [
             ("mlp.dense_h_to_4h.bias", "dense_h_to_4h", "act"),
         ]
@@ -138,11 +135,10 @@ class InjectHFBloomMLPPolicy(ModuleInjectPolicy):
             for rule in replace_rules:
                 if rule[0] in name:
                     new_name = name.replace(rule[1], rule[2])
-            if new_name:
-                new_names.append(new_name)
-                old_names.append(name)
+            if new_name is not None:
+                name_pairs.append((name, new_name))
 
-        for old_name, new_name in zip(old_names, new_names):
+        for old_name, new_name in name_pairs:
             state_dict[new_name] = state_dict.pop(old_name)
 
         return state_dict

--- a/epoi/inject/policy/gpt.py
+++ b/epoi/inject/policy/gpt.py
@@ -167,8 +167,7 @@ class InjectHFGPTAttentionPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def load_state_dict_post_hook(state_dict):
-        new_names = []
-        old_names = []
+        name_pairs = []
         replace_rules = [
             # GPT-2
             ("attn.c_attn.weight", "c_attn", "qkv"),
@@ -184,11 +183,10 @@ class InjectHFGPTAttentionPolicy(ModuleInjectPolicy):
             for rule in replace_rules:
                 if rule[0] in name:
                     new_name = name.replace(rule[1], rule[2])
-            if new_name:
-                new_names.append(new_name)
-                old_names.append(name)
+            if new_name is not None:
+                name_pairs.append((name, new_name))
 
-        for old_name, new_name in zip(old_names, new_names):
+        for old_name, new_name in name_pairs:
             param = state_dict.pop(old_name)
             if "attn.c_attn.weight" in old_name or "attn.c_proj.weight" in old_name:
                 state_dict[new_name] = param.transpose(-1, 0).contiguous()
@@ -323,8 +321,7 @@ class InjectHFGPTMLPPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def load_state_dict_post_hook(state_dict):
-        new_names = []
-        old_names = []
+        name_pairs = []
         replace_rules = [
             # GPT-2, GPTNeo
             ("mlp.c_fc.weight", "c_fc", "fc_in"),
@@ -341,11 +338,10 @@ class InjectHFGPTMLPPolicy(ModuleInjectPolicy):
             for rule in replace_rules:
                 if rule[0] in name:
                     new_name = name.replace(rule[1], rule[2])
-            if new_name:
-                new_names.append(new_name)
-                old_names.append(name)
+            if new_name is not None:
+                name_pairs.append((name, new_name))
 
-        for old_name, new_name in zip(old_names, new_names):
+        for old_name, new_name in name_pairs:
             param = state_dict.pop(old_name)
             if is_gpt2 and ("mlp.c_fc.weight" in old_name or "mlp.c_proj.weight" in old_name):
                 state_dict[new_name] = param.transpose(-1, 0).contiguous()

--- a/epoi/inject/policy/gpt.py
+++ b/epoi/inject/policy/gpt.py
@@ -165,6 +165,38 @@ class InjectHFGPTAttentionPolicy(ModuleInjectPolicy):
 
         return wrapped_forward
 
+    @staticmethod
+    def load_state_dict_post_hook(state_dict):
+        new_names = []
+        old_names = []
+        replace_rules = [
+            # GPT-2
+            ("attn.c_attn.weight", "c_attn", "qkv"),
+            ("attn.c_attn.bias", "c_attn", "qkv"),
+            ("attn.c_proj", "c_proj", "out_proj"),
+            # GPTNeo, GPTJ
+            ("attn.c_attn.q_proj", "q_proj", "query"),
+            ("attn.c_attn.k_proj", "k_proj", "key"),
+            ("attn.c_attn.v_proj", "v_proj", "value"),
+        ]
+        for name in state_dict.keys():
+            new_name = None
+            for rule in replace_rules:
+                if rule[0] in name:
+                    new_name = name.replace(rule[1], rule[2])
+            if new_name:
+                new_names.append(new_name)
+                old_names.append(name)
+
+        for old_name, new_name in zip(old_names, new_names):
+            param = state_dict.pop(old_name)
+            if "attn.c_attn.weight" in old_name or "attn.c_proj.weight" in old_name:
+                state_dict[new_name] = param.transpose(-1, 0).contiguous()
+            else:
+                state_dict[new_name] = param
+
+        return state_dict
+
 
 class InjectHFGPTMLPPolicy(ModuleInjectPolicy):
     @staticmethod
@@ -288,3 +320,36 @@ class InjectHFGPTMLPPolicy(ModuleInjectPolicy):
             "resid_pdrop": resid_pdrop,
         }
         return new_args
+
+    @staticmethod
+    def load_state_dict_post_hook(state_dict):
+        new_names = []
+        old_names = []
+        replace_rules = [
+            # GPT-2, GPTNeo
+            ("mlp.c_fc.weight", "c_fc", "fc_in"),
+            ("mlp.c_fc.bias", "c_fc", "act"),
+            ("mlp.c_proj", "c_proj", "fc_out"),
+            # GPTJ
+            ("mlp.fc_in.bias", "fc_in", "act"),
+        ]
+        is_gpt2 = False
+        for name in state_dict.keys():
+            new_name = None
+            # a trick to see whether the target model is GPT-2...
+            is_gpt2 |= ("attn.c_attn.weight" in name or "attn.qkv" in name)
+            for rule in replace_rules:
+                if rule[0] in name:
+                    new_name = name.replace(rule[1], rule[2])
+            if new_name:
+                new_names.append(new_name)
+                old_names.append(name)
+
+        for old_name, new_name in zip(old_names, new_names):
+            param = state_dict.pop(old_name)
+            if is_gpt2 and ("mlp.c_fc.weight" in old_name or "mlp.c_proj.weight" in old_name):
+                state_dict[new_name] = param.transpose(-1, 0).contiguous()
+            else:
+                state_dict[new_name] = param
+
+        return state_dict

--- a/epoi/inject/policy/t5.py
+++ b/epoi/inject/policy/t5.py
@@ -38,16 +38,16 @@ class InjectHFT5AttentionPolicy(ModuleInjectPolicy):
 
     @staticmethod
     def assign_params(this, orig, **kwargs):
-        this.query.weight = orig.q.weight
-        this.query.bias = orig.q.bias
-        this.key.weight = orig.k.weight
-        this.key.bias = orig.k.bias
-        this.value.weight = orig.v.weight
-        this.value.bias = orig.v.bias
-        this.out.weight = orig.o.weight
-        this.out.bias = orig.o.bias
+        this.q.weight = orig.q.weight
+        this.q.bias = orig.q.bias
+        this.k.weight = orig.k.weight
+        this.k.bias = orig.k.bias
+        this.v.weight = orig.v.weight
+        this.v.bias = orig.v.bias
+        this.o.weight = orig.o.weight
+        this.o.bias = orig.o.bias
         if hasattr(orig, "relative_attention_bias"):
-            this.relative_attention_bias.embeddings.weight = (
+            this.relative_attention_bias.weight = (
                 orig.relative_attention_bias.weight
             )
 


### PR DESCRIPTION
See https://github.com/comaniac/epoi/issues/4. But I realized that simply overriding `_load_from_state_dict` does not work, because HF uses `named_parameters` to decide whether to gather the parameter before calling `_load_from_state_dict` (see [lines](https://github.com/huggingface/transformers/blob/66ded238cd04e29ba98485984dd647e7d37d1603/src/transformers/modeling_utils.py#L531-L539)). So I chose to simply mock `load_state_dict` called [here](https://github.com/huggingface/transformers/blob/66ded238cd04e29ba98485984dd647e7d37d1603/src/transformers/modeling_utils.py#L2630).

Test scrips:
```
ctx = InjectModuleContext([InjectHFBloomAttentionPolicy, InjectHFBloomMLPPolicy])
ctx.__enter__()
model = AutoModelForCausalLM.from_pretrained("bigscience/bloom-560m") # bert/gpt2/t5
ctx.__exit__(None, None, None)
```